### PR TITLE
Fix record sorting in ParallelIndexer

### DIFF
--- a/lib/elasticsearch/rails/ha/parallel_indexer.rb
+++ b/lib/elasticsearch/rails/ha/parallel_indexer.rb
@@ -33,7 +33,7 @@ module Elasticsearch
           return if @pool_size < 1
 
           # get all ids since we can't assume there are no holes in the PK sequencing
-          ids = klass.order('id ASC').pluck(:id)
+          ids = klass.reorder('id ASC').pluck(:id)
           offsets = []
           ids.each_slice(@pool_size) do |chunk|
             #puts "chunk: size=#{chunk.size} #{chunk.first}..#{chunk.last}"


### PR DESCRIPTION
If the model class already has an ordering set using default_scope, the offset logic will generate gaps because the call to order() will effectively be a sub-sort. Calling reorder() forces the correct sorting to happen.